### PR TITLE
proposals:  Add tls and atomic clarification proposals

### DIFF
--- a/_proposals/atomic-boundary.md
+++ b/_proposals/atomic-boundary.md
@@ -1,0 +1,34 @@
+---
+title: Clarification on Atomic Boundaries (P16)
+category: draft
+date: 2017-08-19 18:21
+author: Stafford Horne
+---
+
+Section `7.3 Atomicity` explains that a upon load a reservation is made at
+the address of the load memory location and that subsequent stores to the
+same memory location will cancel the reservation.  It is not clear whether
+stores of byte or half-word size overlapping the memory location cause
+reservation cancellation.
+
+In current implementations stores anywhere within the 32-bit boundary will
+invalidate the memory reservation.  This should be clarified.
+
+## Changes
+
+Change the sentence in `7.3 Atomicity` from:
+
+  The reservation for a subsequent l.swa is cancelled if another store to
+  the same memory location occur, another master writes the same memory
+  location (snoop hit), another l.swa (to any memory location) is executed,
+  another l.lwa is executed or a context switch (exception) occur.
+
+to 
+
+  The reservation for a subsequent l.swa is cancelled if another store
+  *overlapping* the same memory location occurs, another master writes
+  *overlapping* the same memory location (snoop hit), another l.swa (to any 
+  memory location) is executed, another l.lwa is executed or a context
+  switch (exception) occur.  *The overlapping writes may be byte or
+  half-word size.*
+

--- a/_proposals/tls.md
+++ b/_proposals/tls.md
@@ -1,0 +1,26 @@
+---
+title: Designation of r10 for TLS (P15)
+category: draft
+date: 2017-08-19 17:54
+author: Stafford Horne
+---
+
+In the Linux kernel and GCC r10 is already being used for TLS, so add it to
+the spec.
+
+## Changes
+
+Update section `16.2.1 Register Usage` usage of R10 from 'Callee-saved
+register' to 'Thread Local Storage'.
+
+## Additions
+
+In the assigned roles tables of section `16.2.1 Register Usage` explain:
+
+<pre>
+
+| R10 [TLS] | *Thread Local Storage* used to locate the thread local
+              storage structure.  This mechanism, as explained in the GCC
+              manual, allows variables to be **allocated such that there is
+              one instance of the variable per extant thread**.
+</pre>


### PR DESCRIPTION
This patch adds a proposals to reserve r10 for Thread local storage and
clarifies some conditions with overlapping writes to atomic reserve
addresses.