### PR TITLE
Website update to announce Architecture r1.2

### DIFF
--- a/_posts/2017-10-22-openrisc-arch1.2.md
+++ b/_posts/2017-10-22-openrisc-arch1.2.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "Announcing Architecture Revision 1.2"
+description: ""
+category:
+tags: []
+author: Stafford Horne
+---
+{% include JB/setup %}
+
+We are pleased to announce that a new OpenRISC architecture specification
+[revision 1.2](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.2-rev0.pdf)
+has been released.  This release formalizes a few items which have already been
+implemented into our toolchains and Linux as well as describes the multicore
+OpenRISC architecture.
+
+See the full details on the [release](/revisions/r1.2) page.
+ 
+## Update on Upstreaming Effort
+
+In order for the new features to be useful to most users they must be available
+in OpenRISC software.  Stafford is working on submitting multicore patches
+upstream for the below components.  The toolchains already support multicore
+thanks to work done previously be Stefan Wallentowitz.
+
+ - Linux [openrisc-4.14-smp-qspinlock-v3](https://github.com/stffrdhrn/linux/tree/openrisc-4.14-smp-qspinlock-v3) expected to land in 4.15
+ - QEMU [openrisc-smp-v2](https://github.com/stffrdhrn/qemu/tree/openrisc-smp-v2) expected to land in 2.11
+ - FuseSoC [multicore-v2](https://github.com/stffrdhrn/fusesoc-cores/tree/multicore-v2) expected to land soon
+ - OpenOCD [or1k-multicore](https://github.com/stffrdhrn/openocd/tree/or1k-multicore) submitted on April 9th to gerrit but no progress

--- a/_proposals/atomic-boundary.md
+++ b/_proposals/atomic-boundary.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: Clarification on Atomic Boundaries (P16)
-category: draft
+category: r1.2
 date: 2017-08-18 18:21
 author: Stafford Horne
 ---

--- a/_proposals/core-identifier-and-number-of-cores.md
+++ b/_proposals/core-identifier-and-number-of-cores.md
@@ -1,14 +1,19 @@
 ---
 layout: proposal
 title: Core Identifier and Number of Cores (P1)
-category: draft
+category: r1.2
 date: 2015-03-03 10:34
 author: Wallento
 ---
 
-To enable multicore systems, a Special Purpose Register 'Core ID' is needed. Although it is principally not necessary, but allows for a self-contained solution, I furthermore propose a 'Number of Cores' register, which contains the number of cores in a SMP cluster.
+To enable multicore systems, a Special Purpose Register 'Core ID' is needed.
+Although it is principally not necessary, but allows for a self-contained
+solution, I furthermore propose a 'Number of Cores' register, which contains the
+number of cores in a SMP cluster.
 
-Proposal: Use system status register address space 128+ for multicore specifics. I think there may further things come up, so that it may make sense to reserve some space.
+Proposal: Use system status register address space 128+ for multicore specifics.
+I think there may further things come up, so that it may make sense to reserve
+some space.
 
 This is already in mor1kx..
 

--- a/_proposals/tls.md
+++ b/_proposals/tls.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: Designation of r10 for TLS (P15)
-category: draft
+category: r1.2
 date: 2017-08-18 17:54
 author: Stafford Horne
 ---

--- a/_revisions/r1.2.md
+++ b/_revisions/r1.2.md
@@ -1,26 +1,30 @@
 ---
 layout: page
 title: Revision 1.2
-date: 2016-10-18
-category: draft
+date: 2017-10-21
+category: released
 tagline: 
 ---
 {% include JB/setup %}
- - Download `n/a`
- - Changes
-   - Reserve register `r10` for thread local storage 
+ - **Download** [pdf](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.2-rev0.pdf)
+ - **Changes**
+   - Core Identifier and Number of Cores (P1)
+   - Reserve register `r10` for thread local storage (P15)
+   - Clarification on Atomic Boundaries (P16)
+   - Various typos fixes and cleanups
+   - Multicore support and ompic
+ - **Author** Stafford Horne <shorne@gmail.com> 
 
+<!--more--> 
+## Details of Additions/Changes
 
-## Proposed Additions/Changes
+{% for proposal in site.proposals %}
+  {% if proposal.category == "r1.2" %}
 
-### Reserve R10 for TLS (P1)
-
-Currently `r10` is marked as th callee saved register in the specification, 
-however in GCC and libc it is used as thread local storage. 
-
-This proposal is to update the spec to specify that r10 is to be used for
-thread local storage.
-
- - Author - Stafford Horne <shorne@gmail.com> 
- - Supporters - 
+### [{{ proposal.title }}]({{proposal.url}})
+*{{proposal.date | date: "%Y-%m-%d"}} - {{proposal.author}}*
+{{proposal.excerpt}}
+---
+  {% endif %}
+{% endfor %}
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ tagline: Project Overview
 
 Welcome to the project overview of the OpenRISC project. The major
 goal of the project it to create a free and open processor for
-embedded system. This includes:
+embedded systems. This includes:
 
 - a free and open RISC instruction set architecture with DSP features
 


### PR DESCRIPTION
This is a short post announcing the new architecture revision 1.2.

Please add what you like.  Some things do consider:
  - @wallento who else helped with adding multicore support to toolchains?
  - @olofk @skristiansson @olofk do any of you want to be be listed as supporters/signoff on the specification revision page?  There is no mention of it now but it might be nice to have a **SIgned Of by* ...
  - Does anyone know who we need to ping get the OpenOCD changes upstream?