### PR TITLE
Page updates for spec verison 1.3

### DIFF
--- a/_posts/2019-06-04-openrisc-arch1.3.md
+++ b/_posts/2019-06-04-openrisc-arch1.3.md
@@ -1,0 +1,46 @@
+---
+layout: post
+title: "Announcing Architecture Version 1.3"
+description: ""
+category:
+tags: []
+author: Stafford Horne
+---
+{% include JB/setup %}
+
+It has been been a few years from our last new OpenRISC specification version.
+But, it's been a busy few years of getting GDB and GCC ports upstream.  Now with
+the GCC port upstream we are able to make progress and this new architecture
+revision does just that bringing in a handful of new instructions:
+
+   - New instruction `lf.stod.d` for converting floats from single precision to
+     double prevision
+   - New instruction `lf.dtos.d` for converting floats from double precision to
+     single precision
+   - New instruction `l.adrp` for constructing addresses
+   - New instructions `lf.sfun*` to support unordered compares
+   - New instruction `l.lf` to load floats with NaN boxing on 64-bit hardware
+   - Removed instruction `lf.rem.*` floating point remainder calculation 
+
+With that said OpenRISC architecture specification
+[version 1.3](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.3-rev1.pdf)
+has been released.  Quite a few of the instructions and changes are already
+implemented in OpenRISC soft cores and toolchains so you should be able to use
+them right away.
+
+See the full details on the [release](/revisions/r1.3) page.
+ 
+## Update on Upstreaming Effort
+
+In order for the new features to be useful to most users they must be available
+in OpenRISC software.  Stafford is working on submitting toolchain patches for
+the following components.
+
+   - [GCC](https://github.com/stffrdhrn/gcc/tree/or1k-fpu-2) - Patches, ready
+     to go but depends on binutils being in first.
+   - [binutils](https://github.com/stffrdhrn/binutils-gdb/tree/orfpx64a32-3) - Working
+     on adding test cases for the `l.adrp` instruction.  Should send for upstream
+     review in a few weeks.
+   - [cgen](https://github.com/stffrdhrn/cgen)- Added unordered support to
+     support binutils, [patches submitted](https://sourceware.org/ml/cgen/2019-q2/msg00013.html) waiting for review.
+

--- a/_posts/2019-06-04-openrisc-arch1.3.md
+++ b/_posts/2019-06-04-openrisc-arch1.3.md
@@ -8,19 +8,24 @@ author: Stafford Horne
 ---
 {% include JB/setup %}
 
-It has been been a few years from our last new OpenRISC specification version.
+It has been been a few years since the release of [OpenRISC version 1.2](/revisions/r1.2).
 But, it's been a busy few years of getting GDB and GCC ports upstream.  Now with
 the GCC port upstream we are able to make progress and this new architecture
 revision does just that bringing in a handful of new instructions:
 
-   - New instruction `lf.stod.d` for converting floats from single precision to
-     double prevision
-   - New instruction `lf.dtos.d` for converting floats from double precision to
-     single precision
-   - New instruction `l.adrp` for constructing addresses
-   - New instructions `lf.sfun*` to support unordered compares
-   - New instruction `l.lf` to load floats with NaN boxing on 64-bit hardware
-   - Removed instruction `lf.rem.*` floating point remainder calculation 
+ - New instruction `lf.stod.d` for converting floats from single precision to
+   double prevision
+ - New instruction `lf.dtos.d` for converting floats from double precision to
+   single precision
+ - New instruction `l.adrp` for constructing addresses
+ - New instructions `lf.sfun*` to support unordered compares
+ - New instruction `l.lf` to load floats with NaN boxing on 64-bit hardware
+ - Remove instructions `lf.rem.d` and `lf.rem.s` used for calculating floating point remainder
+
+Perhaps one of the biggest new features is the addition of support for
+performing double precision floating point operations using 32-bit hardware.
+The is by way of the new [ORFPX64A32](/proposals/orfpx64a32)
+instruction set extension.
 
 With that said OpenRISC architecture specification
 [version 1.3](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.3-rev1.pdf)
@@ -29,8 +34,18 @@ implemented in OpenRISC soft cores and toolchains so you should be able to use
 them right away.
 
 See the full details on the [release](/revisions/r1.3) page.
- 
-## Update on Upstreaming Effort
+
+## Soft Core Support
+
+Some soft cores already support the new instructions if you want to try them out
+you can find them here:
+
+ - [mor1kx](https://github.com/openrisc/mor1kx) - has support for `lf.sfun*`
+   operations.
+ - [or1k_marocchino](https://github.com/openrisc/or1k_marocchino) - has support
+   for `lf.sfun*` operations as well as the  `ORFPX64A32` extension.
+
+## Software Upstreaming Effort
 
 In order for the new features to be useful to most users they must be available
 in OpenRISC software.  Stafford is working on submitting toolchain patches for
@@ -44,3 +59,4 @@ the following components.
    - [cgen](https://github.com/stffrdhrn/cgen)- Added unordered support to
      support binutils, [patches submitted](https://sourceware.org/ml/cgen/2019-q2/msg00013.html) waiting for review.
 
+Please feel free to contact us via the [mailing list](/community) if you have any questions.

--- a/_proposals/corrections.md
+++ b/_proposals/corrections.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORBIS64/ORFPX64 Corrections (P13)
-category: draft
+category: r1.3
 date: 2015-03-06 16:45
 author: Rth
 ---

--- a/_proposals/ladrp.md
+++ b/_proposals/ladrp.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORBIS64/ORFPX64 Additions - l.adrp (P9)
-category: draft
+category: r1.3
 date: 2015-03-06 16:41
 author: Rth
 ---

--- a/_proposals/lfmadd.md
+++ b/_proposals/lfmadd.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORFPX32/ORFPX64 - lf.madd (P6)
-category: draft
+category: r1.3
 date: 2015-03-06 21:57
 author: Rth
 ---

--- a/_proposals/lfsf.md
+++ b/_proposals/lfsf.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORFPX32/ORFPX64 - lf.sf* (P7)
-category: draft
+category: r1.3
 date: 2015-03-06 23:25
 author: Rth
 ---

--- a/_proposals/lstod-ldtos.md
+++ b/_proposals/lstod-ldtos.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORBIS64/ORFPX64 Additions - l.stod, l.dtos (P11) 
-category: draft
+category: r1.3
 date: 2015-03-06 16:43
 author: Rth
 ---

--- a/_proposals/orfpx64a32.md
+++ b/_proposals/orfpx64a32.md
@@ -1,7 +1,7 @@
 ---
 layout: proposal
 title: ORFPX64A32 (P14)
-category: draft
+category: r1.3
 date: 2015-03-12 15:35
 author: BAndViG
 ---

--- a/_revisions/r1.0.md
+++ b/_revisions/r1.0.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Revision 1.0
+title: Version 1.0
 date: 2012-12-14
 category: released
 tagline: 

--- a/_revisions/r1.1.md
+++ b/_revisions/r1.1.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Revision 1.1
+title: Version 1.1
 date: 2014-05-12
 category: released
 tagline: 

--- a/_revisions/r1.2.md
+++ b/_revisions/r1.2.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Revision 1.2
+title: Version 1.2
 date: 2017-10-21
 category: released
 tagline: 

--- a/_revisions/r1.3.md
+++ b/_revisions/r1.3.md
@@ -9,11 +9,12 @@ tagline:
  - **Download** [pdf](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.3-rev1.pdf)
  - **Changes**
    - ORFPX64A32 double-precision floating point operations on 32-bit hardware using register pairs (P14)
+   - Define `CPUCFGR[15]` for ORFPX64A32 presence flag
    - New instructions `lf.stod.d` `lf.dtos.d` for converting between single and double precision floats (P7)
    - New instruction `l.adrp` for constructing addresses (P9)
    - New instructions `lf.sfun*` to support unordered compares (P11)
    - New instruction `l.lf` to load floats with NaN boxing on 64-bit hardware
-   - Removed instruction `lf.rem.*` floating point remainder calculation
+   - Removed instructions `lf.rem.d` and `lf.rem.s` used to calculate floating point remainder
    - Various cleanups and clarifications on internal rounding, truncation and others
      - Clarification on internal rounding for `lf.madd.*` instructions (P6)
      - Update `l.div*` to mention fraction is truncated

--- a/_revisions/r1.3.md
+++ b/_revisions/r1.3.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: Version 1.3
+date: 2019-06-04
+category: proposal
+tagline: 
+---
+{% include JB/setup %}
+ - **Download** [pdf](https://raw.githubusercontent.com/openrisc/doc/master/openrisc-arch-1.3-rev1.pdf)
+ - **Changes**
+   - ORFPX64A32 double-precision floating point operations on 32-bit hardware using register pairs (P14)
+   - New instructions `lf.stod.d` `lf.dtos.d` for converting between single and double precision floats (P7)
+   - New instruction `l.adrp` for constructing addresses (P9)
+   - New instructions `lf.sfun*` to support unordered compares (P11)
+   - New instruction `l.lf` to load floats with NaN boxing on 64-bit hardware
+   - Removed instruction `lf.rem.*` floating point remainder calculation
+   - Various cleanups and clarifications on internal rounding, truncation and others
+     - Clarification on internal rounding for `lf.madd.*` instructions (P6)
+     - Update `l.div*` to mention fraction is truncated
+     - Update `lf.ftoi.*` to mention fraction is truncated (P13)
+     - Add single-precision floating point NaN boxing on 64-bit hardware
+     - Updated machine instruction table (Section 18), removed unused page column, added class and opcode for quick reference
+     - Document `lf.sf*` floating point exceptions
+     - Document that floating point exceptions do write back results to registers
+     - Define addresses for `FPMADD*` and `VMAC*` sprs
+ - **Authors** Stafford Horne <shorne@gmail.com>, Andrey Bacherov <bandvig@mail.ru>
+
+<!--more--> 
+## Details of Additions/Changes
+
+{% for proposal in site.proposals %}
+  {% if proposal.category == "r1.3" %}
+
+### [{{ proposal.title }}]({{proposal.url}})
+*{{proposal.date | date: "%Y-%m-%d"}} - {{proposal.author}}*
+{{proposal.excerpt}}
+---
+  {% endif %}
+{% endfor %}
+

--- a/_revisions/r1.3.md
+++ b/_revisions/r1.3.md
@@ -2,7 +2,7 @@
 layout: page
 title: Version 1.3
 date: 2019-06-04
-category: proposal
+category: released
 tagline: 
 ---
 {% include JB/setup %}

--- a/architecture.md
+++ b/architecture.md
@@ -73,7 +73,7 @@ The revision process is:
  - After the proposal is added to the specification and the revision page
    is create mark all proposal drafts as accepted.
 
-## Revisions
+## Published Versions
 
 This is a list of historical revisions that have been reviewed, signed-off and
 published.


### PR DESCRIPTION
New spec as discussed on the mailing list (https://lists.librecores.org/pipermail/openrisc/2019-April/001958.html)

Also see PRs from openrisc/doc [2](https://github.com/openrisc/doc/pull/2) and [3](https://github.com/openrisc/doc/pull/3).